### PR TITLE
Upgrade to manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   	"name": "Quotes New Tab",
     "author": "Emil Carlsson",
   	"description": "A new motivational quote in every new tab.",
-  	"version": "2.0.0",
-  	"manifest_version": 2,
+  	"version": "3.0.0",
+  	"manifest_version": 3,
   	"permissions" : [
       "management",
       "topSites"


### PR DESCRIPTION
## Prerequisites
Version: v2.0.0
Operating system: Mac OSX
Time of bug: March 15 12:00pm EST

## Steps to reproduce
Visit: https://chromewebstore.google.com/detail/quotes-new-tab/fnhpicigolcacikdjdocmkfnplmefadg?hl=en
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/733bd0be-0189-4013-ab13-8ce6e5d26ac4" />

If you already have the extension installed, you'll see this in your Chrome Extensions:

<img width="861" alt="image" src="https://github.com/user-attachments/assets/5cf13bc5-acb1-47e6-bfe2-cde1cc375d0b" />

### Actual behavior:
Extension is disabled 😢 

### Expected behavior:
An inspirational quote when I open a new tab.

### Steps to fix:
I downloaded the repo, upgraded the version in the manifest, and after uploading a required few files for the Extension Images, I got it working again:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/fa55118f-8dc8-401f-a4ce-6e35e7866f52" />

